### PR TITLE
feat: Add save, edit, and export for generated articles

### DIFF
--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -1,10 +1,11 @@
-import { SavedOutline } from '../types';
+import { SavedOutline, SavedArticle } from '../types';
 
-const STORAGE_KEY = 'ai-outline-generator-saved-outlines';
+const STORAGE_KEY_OUTLINES = 'ai-outline-generator-saved-outlines';
+const STORAGE_KEY_ARTICLES = 'ai-outline-generator-saved-articles';
 
 export const getSavedOutlines = (): SavedOutline[] => {
   try {
-    const data = window.localStorage.getItem(STORAGE_KEY);
+    const data = window.localStorage.getItem(STORAGE_KEY_OUTLINES);
     if (!data) {
       return [];
     }
@@ -20,8 +21,32 @@ export const getSavedOutlines = (): SavedOutline[] => {
 export const saveOutlines = (outlines: SavedOutline[]): void => {
   try {
     const data = JSON.stringify(outlines);
-    window.localStorage.setItem(STORAGE_KEY, data);
+    window.localStorage.setItem(STORAGE_KEY_OUTLINES, data);
   } catch (error) {
-    console.error("Error writing to localStorage", error);
+    console.error("Error writing to localStorage for outlines", error);
+  }
+};
+
+export const getSavedArticles = (): SavedArticle[] => {
+  try {
+    const data = window.localStorage.getItem(STORAGE_KEY_ARTICLES);
+    if (!data) {
+      return [];
+    }
+    const articles: SavedArticle[] = JSON.parse(data);
+    // Sort by creation date, newest first
+    return articles.sort((a, b) => b.createdAt - a.createdAt);
+  } catch (error) {
+    console.error("Error reading articles from localStorage", error);
+    return [];
+  }
+};
+
+export const saveArticles = (articles: SavedArticle[]): void => {
+  try {
+    const data = JSON.stringify(articles);
+    window.localStorage.setItem(STORAGE_KEY_ARTICLES, data);
+  } catch (error) {
+    console.error("Error writing articles to localStorage", error);
   }
 };

--- a/types.ts
+++ b/types.ts
@@ -13,3 +13,15 @@ export interface SavedOutline extends OutlineData {
   id: string;
   createdAt: number;
 }
+
+export interface ArticleContentPart {
+  section: string;
+  content: string;
+}
+
+export interface SavedArticle {
+  id: string;
+  createdAt: number;
+  outline: OutlineData;
+  content: ArticleContentPart[];
+}


### PR DESCRIPTION
This feature adds the capability to save, edit, delete, and export the fully generated articles.

Key changes:
- Extended `types.ts` and `services/storageService.ts` to handle the storage of full articles.
- Replaced the static `ArticleDisplay` with an `ArticleEditor` component, allowing the generated text to be modified.
- Implemented handler functions (`handleSaveOrUpdateArticle`, `handleEditArticle`, `handleDeleteArticle`) to manage the lifecycle of saved articles.
- Added a "Saved Articles" list to the UI for easy access to past work.
- Implemented a `generateArticleMarkdown` function and connected it to a new UI button to allow exporting the final article to Markdown.