### PR TITLE
feat: Add edit and save for final markdown output

### DIFF
--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -1,7 +1,8 @@
-import { SavedOutline, SavedArticle } from '../types';
+import { SavedOutline, SavedArticle, SavedMarkdown } from '../types';
 
 const STORAGE_KEY_OUTLINES = 'ai-outline-generator-saved-outlines';
 const STORAGE_KEY_ARTICLES = 'ai-outline-generator-saved-articles';
+const STORAGE_KEY_MARKDOWNS = 'ai-outline-generator-saved-markdowns';
 
 export const getSavedOutlines = (): SavedOutline[] => {
   try {
@@ -48,5 +49,28 @@ export const saveArticles = (articles: SavedArticle[]): void => {
     window.localStorage.setItem(STORAGE_KEY_ARTICLES, data);
   } catch (error) {
     console.error("Error writing articles to localStorage", error);
+  }
+};
+
+export const getSavedMarkdowns = (): SavedMarkdown[] => {
+  try {
+    const data = window.localStorage.getItem(STORAGE_KEY_MARKDOWNS);
+    if (!data) {
+      return [];
+    }
+    const markdowns: SavedMarkdown[] = JSON.parse(data);
+    return markdowns.sort((a, b) => b.createdAt - a.createdAt);
+  } catch (error) {
+    console.error("Error reading markdowns from localStorage", error);
+    return [];
+  }
+};
+
+export const saveMarkdowns = (markdowns: SavedMarkdown[]): void => {
+  try {
+    const data = JSON.stringify(markdowns);
+    window.localStorage.setItem(STORAGE_KEY_MARKDOWNS, data);
+  } catch (error) {
+    console.error("Error writing markdowns to localStorage", error);
   }
 };

--- a/types.ts
+++ b/types.ts
@@ -25,3 +25,10 @@ export interface SavedArticle {
   outline: OutlineData;
   content: ArticleContentPart[];
 }
+
+export interface SavedMarkdown {
+  id: string;
+  createdAt: number;
+  title: string;
+  content: string;
+}


### PR DESCRIPTION
This feature adds the capability to edit, save, and manage the final Markdown output as a separate entity.

Key changes:
- Extended `types.ts` and `services/storageService.ts` to handle a new `SavedMarkdown` data type.
- The `MarkdownOutput` component was refactored into a `MarkdownEditor`, allowing direct editing of the markdown text in a textarea.
- Implemented handler functions (`handleSaveOrUpdateMarkdown`, `handleEditMarkdown`, `handleDeleteMarkdown`) to manage the lifecycle of saved markdowns.
- Added a "Saved Markdowns" list to the UI for easy access to final, edited markdown texts.